### PR TITLE
chore: retrieve isLoading from SWR

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "^7.37.0",
     "react-hot-toast": "^2.4.0",
-    "swr": "^1.3.0"
+    "swr": "^2.0.0"
   },
   "devDependencies": {
     "@babel/helper-plugin-utils": "^7.19.0",

--- a/src/hooks/useFetchWithCache.ts
+++ b/src/hooks/useFetchWithCache.ts
@@ -1,5 +1,4 @@
-import useSWR, { Key } from 'swr'
-import { Fetcher, SWRConfiguration } from 'swr/dist/types'
+import useSWR, { Fetcher, Key, SWRConfiguration } from 'swr'
 import { useState, useEffect } from 'react'
 
 export function useFetchWithCache<Data = any, Error = any>(
@@ -7,11 +6,13 @@ export function useFetchWithCache<Data = any, Error = any>(
   fn: Fetcher<Data> | null = null,
   config?: SWRConfiguration<Data, Error>,
 ) {
-  const { data, error, ...rest } = useSWR<Data, Error>(key, fn, config)
+  const { data, error, isLoading, ...rest } = useSWR<Data, Error>(
+    key,
+    fn,
+    config,
+  )
   const [internalData, setInternalData] = useState<Data>()
-
   const isFirstLoading = !internalData && !error
-  const loading = !data && !error
 
   useEffect(() => {
     if (data) {
@@ -19,5 +20,5 @@ export function useFetchWithCache<Data = any, Error = any>(
     }
   }, [data])
 
-  return { data: internalData, isFirstLoading, loading, error, ...rest }
+  return { data: internalData, isFirstLoading, isLoading, error, ...rest }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13284,10 +13284,12 @@ swagger2openapi@^7.0.8:
     yaml "^1.10.0"
     yargs "^17.0.1"
 
-swr@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/swr/-/swr-1.3.0.tgz#c6531866a35b4db37b38b72c45a63171faf9f4e8"
-  integrity sha512-dkghQrOl2ORX9HYrMDtPa7LTVHJjCTeZoB1dqTbnnEDlSvN8JEKpYIYurDfvbQFUUS8Cg8PceFVZNkW0KNNYPw==
+swr@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.0.0.tgz#91d999359e2be92de1a41f6b6711d72be20ffdbd"
+  integrity sha512-IhUx5yPkX+Fut3h0SqZycnaNLXLXsb2ECFq0Y29cxnK7d8r7auY2JWNbCW3IX+EqXUg3rwNJFlhrw5Ye/b6k7w==
+  dependencies:
+    use-sync-external-store "^1.2.0"
 
 symbol-tree@^3.2.4:
   version "3.2.4"
@@ -14049,7 +14051,7 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
-use-sync-external-store@1.2.0:
+use-sync-external-store@1.2.0, use-sync-external-store@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz#7dbefd6ef3fe4e767a0cf5d7287aacfb5846928a"
   integrity sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==


### PR DESCRIPTION
#### What's this PR do?

- [x] Retrieve the `isLoading` state from SWR because they released it in version 2.0.0`. Read more at: https://github.com/vercel/swr/releases/tag/2.0.0


#### Any background context you want to provide? (if appropriate)

- Detecting the `isLoading` state by data and error value is unreliable. There is some edge case that this state will return a false value. It's better when we use the state get from `swr`