### PR TITLE
feat: allow headers from openapi

### DIFF
--- a/orval.config.js
+++ b/orval.config.js
@@ -44,6 +44,7 @@ const MOCK_ME = {
 export default defineConfig({
   app: {
     output: {
+      headers: true,
       mode: 'tags-split',
       workspace: './src/api',
       target: './app.ts',


### PR DESCRIPTION
#### What's this PR do?

OpenAPI comes with a key that allows us to identify whether a variable is from the query parameter, body, or **header** parameter. One particular case that happens a lot is CORS, and if we allow for more secured CORS request, we will eventually have to transform the headers within the request or do some jumps to get it working. This PR enables headers to be generated with other parameters, to allow easy input of header parameters. This is most likely a **breaking change**, as it alters the arity of the functions generated from Orval.

- [x] Update orval to allow passing headers from OpenAPI

<img width="823" alt="image" src="https://github.com/dwarvesf/nextjs-boilerplate/assets/1130103/76c2b63e-41a1-4a16-8ec1-bda74386376c">
<img width="485" alt="image" src="https://github.com/dwarvesf/nextjs-boilerplate/assets/1130103/0493ae5e-4025-494e-a9f5-8c8aed79599b">

---
An example parameter that uses `"in": "header"` to allow orval to generate header params:

```
{
   ...
   "parameters":[
      {
         "required":false,
         "schema":{
            "title":"Authorization",
            "type":"string"
         },
         "name":"authorization",
         "in":"query"
      },
      {
         "required":false,
         "schema":{
            "title":"Origin",
            "type":"string"
         },
         "name":"origin",
         "in":"header"
      },
      {
         "required":false,
         "schema":{
            "title":"Access-Control-Request-Headers",
            "type":"string"
         },
         "name":"access-control-request-headers",
         "in":"header"
      }
   ]
   ...
}
```